### PR TITLE
Store parsed schema in Registry to avoid reparsing it every time

### DIFF
--- a/lib/Registry.ts
+++ b/lib/Registry.ts
@@ -14,11 +14,7 @@ class Registry {
     const key = filter.id ? filter.id : `${filter.subject}:${filter.version}`;
     /* Check if schema is in cache: */
     if (this.cache.has(key)) {
-      const { id, schema } = this.cache.get(key);
-      return {
-        id,
-        schema: avsc.parse(schema, this.parseOptions)
-      };
+      return this.cache.get(key);
     }
 
     /* Schema is not in cache, download it: */
@@ -44,7 +40,7 @@ class Registry {
     const parsedSchema = avsc.parse(schema, this.parseOptions);
 
     /* Result */
-    this.cache.set(key, { id: filter.id || id, schema });
+    this.cache.set(key, { id: filter.id || id, schema: parsedSchema });
     return { id: filter.id || id, schema: parsedSchema };
   }
   async encode(subject, version, originalMessage) {


### PR DESCRIPTION
Hi Ivo! I hope you're doing fine :)

We have a problem trying to parse long 64 bit integers from the avro messages, due to this limitation: https://github.com/mtth/avsc/wiki/Advanced-usage#custom-long-types

I have implemented on our code the proposed solution of using a custom long type and passing that type to your library with:

```
const kafka = new KafkaAvro({
        clientId: "<client-id>",
        brokers: ["<hostname>:9092"],
        avro: {
            url: "https://<hostname>:<port>",
            parseOptions: { registry: { long: myCustomLongType } }
        }
    })
```

It works fine the first time, but the problem is that sending anything in parseOptions will change the way the schema is parsed:
```
avsc.parse(schema, this.parseOptions)
```
is altering the contents of `this.parseOptions`, storing the full schema inside the `registry` attribute.

So the next time we try to decode a message, the `getSchema` method will load the schema from cache and call `avsc.parse` again, but with the already parsed schema in parseOptions.
And `avsc` will throw [this error](https://github.com/mtth/avsc/blob/master/lib/types.js#L107) "duplicate type name: XXX" 

My proposed solution is to store the already parsed schema in the cache instead of the response from the schema registry.
This way we solve the problem, but also save some processing because we don't need to re-parse the schema each time we need to decode a message.

What do you think?
